### PR TITLE
fix: 圖片授權期限

### DIFF
--- a/src/stores/FakeDataStore.js
+++ b/src/stores/FakeDataStore.js
@@ -7,9 +7,9 @@ export default defineStore("fackDataStore", {
       Alex: {
         name: "Alex",
         imageUrl:
-          "https://storage.googleapis.com/vue-course-api.appspot.com/gymplus/1709447755538.jpg?GoogleAccessId=firebase-adminsdk-zzty7%40vue-course-api.iam.gserviceaccount.com&Expires=1742169600&Signature=Tm2yv6O6TFaWWN%2BjC5AGqwAfCoJ%2Bw83D1WLf2IV1oj5GhC7L45UIWrDAnqlXjSV9NsQGawNCXp385%2BESyyJSdb6fDoyyd%2FmEh2oyve0PDpORd0Jeim2Nko6uPkIUw6LG0UWZCsbgdhHJZsX7Pizd8t3o2T5qV6kgOZeine6RWno8UlZc8hVA5TYpEnUp3%2F3V6oggEvNX3g%2FxE2ZzxL2gm%2FP5KJDgnGMXxQla49k7HSDQdh7E6lUCc5KuSk3ZNjAhKZAKJVAPBi7fjHLT4vh00hXJmmbA%2FVAHmlu00HYnpcPOkVwkQO73uCG82Fuav%2BjMw9ED6vqumNZ7S53UsVkVew%3D%3D",
+          "https://storage.googleapis.com/vue-course-api.appspot.com/gymplus/1709447755538.jpg",
         avatarUrl:
-          "https://storage.googleapis.com/vue-course-api.appspot.com/gymplus/1709447738741.png?GoogleAccessId=firebase-adminsdk-zzty7%40vue-course-api.iam.gserviceaccount.com&Expires=1742169600&Signature=f8PYdXtpz0BHP%2BY5WOCKYF%2BLy9bnbaETESAHg7QAa3ePDzELnde0ABaQ0vqhdyn1BUojkGi7wTd59S6u5sajHZfPl%2FG3BsvbZID7Pei3TIOzxcR4e%2FVYBZdsJRmtPJ60YDYUHPaIgyg0J6KkvEdb%2B8RK8oqoFfjEYZVk9aR4iVZFo1%2FHem%2FRKorDBG6l1qU88zeu%2BVzLe41ibSk5R5P6WoX0hz1%2FnP8E4kEBIOqIZ%2B13efI1EDHPnZRWF2mZ85V6yBCZ0JFyplhli8RnKLtH2zj8RCABCMWQ4XbxGhc0bUfjggKfpaIv6GvjWorZk9GJOvHisKpCYog6BHtWOynFAA%3D%3D",
+          "https://storage.googleapis.com/vue-course-api.appspot.com/gymplus/1709447738741.png",
         motto: ["超越自我", "超越極限", "追求卓越的生活方式"],
         teachingExpertise: [
           "高效有氧運動課程設計",
@@ -41,9 +41,9 @@ export default defineStore("fackDataStore", {
       "Olivia Chang": {
         name: "Olivia Chang",
         imageUrl:
-          "https://storage.googleapis.com/vue-course-api.appspot.com/gymplus/1709447581246.jpg?GoogleAccessId=firebase-adminsdk-zzty7%40vue-course-api.iam.gserviceaccount.com&Expires=1742169600&Signature=PgMA%2FH9d0pUMQGK%2B8ht4owzrEsvaYknT5Us2M68FNvLI4YYjK5MffWRn0aASmR5OP1IDlelCKcFn204lV%2BeTplm%2FEBD8MV3wkN7NpGAarRb1RqH%2FqLEi1QUULlGBtL43yEZU7D95aPOdNVd3lQ2iaVmyjSxIGuazB%2FEHeIsRXJMeln%2BlRiGDKVkr4o675LsfWRb9G8cwlISU9NqBiEkQnZFuPUG4Yj2jQLCWGb7KgpybFKqcL2MYNjoHkthdIwM039uGbl92A1MO%2Fga8i6gpkdzjVz8iehKhyAbxBIlFs9ZCuRH7cNisuh%2BovYkJqqKIgIj68iAUkvBf6PrBcZszlA%3D%3D",
+          "https://storage.googleapis.com/vue-course-api.appspot.com/gymplus/1709447581246.jpg",
         avatarUrl:
-          "https://storage.googleapis.com/vue-course-api.appspot.com/gymplus/1709447639859.png?GoogleAccessId=firebase-adminsdk-zzty7%40vue-course-api.iam.gserviceaccount.com&Expires=1742169600&Signature=AXUtogzYmQ4knZ2xyE%2BHqCvkazbGsPnV91dcTJHb%2FcsT%2Fhc5mS03gOMNkpuZLzMmmw0AdDaRFC7Z6zUObX0oxtAj0t21MI0G3LwmD6x7ea40vHcp6mYTOfG8UWRgKwk6BJLLEEtGVEossstVoTtkxoYpU93e%2FSwMJJkPfzB4pHGlngiqD1s3xdptjkXbbhn%2BgVLnPoh9m4eSDDxdJzO1sdRDoQT4dkVdsjO19U%2BD2bVHJyHK6XY5wSZwIIT%2B31K%2BvH5BEA4OYlnskm1nmkXauGm%2FGalQC2A9zhPho2bKuvmH%2Bbdh3zzsODCLdWMDKnkd7PJln6n%2F65pCD%2BkhINkf7A%3D%3D",
+          "https://storage.googleapis.com/vue-course-api.appspot.com/gymplus/1709447639859.png",
         motto: ["勇於挑戰", "超越自我", "不斷突破極限"],
         teachingExpertise: [
           "重量訓練課程設計與執行",
@@ -75,9 +75,9 @@ export default defineStore("fackDataStore", {
       "Jackson Liu": {
         name: "Jackson Liu",
         imageUrl:
-          "https://storage.googleapis.com/vue-course-api.appspot.com/gymplus/1709447716148.jpg?GoogleAccessId=firebase-adminsdk-zzty7%40vue-course-api.iam.gserviceaccount.com&Expires=1742169600&Signature=IyD0UknoC9ebc4bW3KFSaSpo58jBlKCjvnv7iPJ4nnz5QhQxTAZoHZbOffgq8PSjayeb6wZ2oBsKH2GAlbduCvmfDYB2KzcR%2Ffxo4ex%2FUEsG0bZikRTWKqU4AMpeiYotxkZeV%2FztctvUF0wVP41tb1v%2FYQalPFK%2FBQwcjh4Fde41jg02dntMrFm%2BBx5Nkes7eZParPfffyOnvQCvsBqdIJ7sth3wIphin1guzCcEklSV2IgpSo7am7LKUFcx%2F5a337iRjceKFY8GzxBbAifnlS7QFnwB1Gh5KsxYYRwY%2FPO9GPzr54vpoLcegTaHbE6FvGSiZnB3HqBZL64t2ZtmmA%3D%3D",
+          "https://storage.googleapis.com/vue-course-api.appspot.com/gymplus/1709447716148.jpg",
         avatarUrl:
-          "https://storage.googleapis.com/vue-course-api.appspot.com/gymplus/1709447697703.png?GoogleAccessId=firebase-adminsdk-zzty7%40vue-course-api.iam.gserviceaccount.com&Expires=1742169600&Signature=XVwEceR5lzAArAt6SB%2FwMVLc3P%2FcdWcMSnMOLbsfqVEyKvBuvjq%2Bc15gjpleMmjgY0jdcYfbCQaS197%2FUyCFBH64bsoF29E%2FCSAiV%2BtFJboWe%2F6B9BRKF5ydxj4hyBv6nlZ503gjYFZyR%2Fp98asmrYiAfZ%2BzHZqcvCd2ISe02dUxzTZh6DF88wa5qfdwpY369%2FehvGxdTdPCNJbu6z5koABPzb3jyhlnJeL3E2CC67XALlh0KOYtdfzE53wbLJxFuTIy4nwvgvkZ2VHjxXzCKZTvg84fCaeeYcY5RF6otZyg3Bz6d%2FbC13XQthNa7DgV%2BHbEct%2F4xfIcc99u4spOfQ%3D%3D",
+          "https://storage.googleapis.com/vue-course-api.appspot.com/gymplus/1709447697703.png",
         motto: ["心隨運動", "身體超越", "追求健康與快樂的生活"],
         teachingExpertise: [
           "有氧運動課程設計與執行",
@@ -109,9 +109,9 @@ export default defineStore("fackDataStore", {
       Emma: {
         name: "Emma",
         imageUrl:
-          "https://storage.googleapis.com/vue-course-api.appspot.com/gymplus/1709447554726.jpg?GoogleAccessId=firebase-adminsdk-zzty7%40vue-course-api.iam.gserviceaccount.com&Expires=1742169600&Signature=dx%2FT1A2cvaQWmPUMgVluQHPixP6t6zrPyDTTt2VZ8rSXN7T8hpey2HQWX8fWPh10fmPZ7d6ldr%2F%2FYksn16%2Fu9IfMwP5jxlSBf%2F1JkO7Awj5l0CI88eluNKZMjUkweI3S1WWEW5%2FJxdZnmrOi0FRnVeMndJCNZIQ5hhFU4IGigPgTqKfqILAgcdjzIEH9KAuKDhn6QNoZpYPu%2BxTpWbB8fz7PnagzLzVhUyNScZEnZlEeIAOtiO9qkCB1QD4MKErYHnaqDY7ez%2Bct5f9Tozsz8J%2BFBjz2Io4wBkbHxYr8GIG4%2BrguiawA6WkFK6WmacHpJ47GSQx2OZW%2BwkVOFf0vdg%3D%3D",
+          "https://storage.googleapis.com/vue-course-api.appspot.com/gymplus/1709447554726.jpg",
         avatarUrl:
-          "https://storage.googleapis.com/vue-course-api.appspot.com/gymplus/1709447668959.png?GoogleAccessId=firebase-adminsdk-zzty7%40vue-course-api.iam.gserviceaccount.com&Expires=1742169600&Signature=FUgaM1cygrJbd8UVi8D%2B1rEADXMeXpd9S4ZzjYYIeWFNuzuthChEG%2F38Lw%2FYPtIETcovrZwMkagNDwZ1ewOPbOvEw0Xze8h3udb2zBwibAPldJECuBSE6ToAsTo8mPOoI4576tpRexnWsf8VadcM1oLMAfBbES3KPzgKAlgSz4yDQIQxVnp9PHWzWQoXF38nvMXm4d6QQrSr8No37gnQy5EaVSAGX17b2InroHWyj6dxzjuLuIwQvbHbYdwlCxsNdV2VM%2FGSlSEg14jYZLuzUQ8fFfOAUonyuhiev51ECMZxMYpvtD5A1Re09F%2Fmei21Q4GcIdlDp1HaowFWrlJrJw%3D%3D",
+          "https://storage.googleapis.com/vue-course-api.appspot.com/gymplus/1709447668959.png",
         motto: ["身心合一", "尋找平衡", "靈動無限"],
         teachingExpertise: [
           "瑜珈基本姿勢與呼吸法",
@@ -143,9 +143,9 @@ export default defineStore("fackDataStore", {
       Dhalsim: {
         name: "Dhalsim",
         imageUrl:
-          "https://storage.googleapis.com/vue-course-api.appspot.com/gymplus/1709447603909.jpg?GoogleAccessId=firebase-adminsdk-zzty7%40vue-course-api.iam.gserviceaccount.com&Expires=1742169600&Signature=jUWkaaHlgBXwuyGOYGpjZftzVb%2BinCzSjhNryatOyF9pkcNEa8NcAhCVGMWgGAlszsz2SG2tkcbEKQcKmAWW73BsHbi2p5kXlQVgG4MXqT%2BRllAwL%2B6F0ja0zsFKAeKn7EYEBahnxLD3u8AvfXzQngWwqNU8wVD4FaFQa%2FoN0NibgMs6%2Fr1I2Raj0KEN8gQrv53vgeOJ%2FOYjzJ%2Ffyebjtzp%2BKsKgJt2cNJ6fZTYE7nJQcanl169P0hx5zhsSWYWLp%2B%2FI2cXOEl%2BcLb%2FpBncF84GXSg2baMPmFR6yJbJhBfWerHSIYfKS%2B2tX5dFMWlPzNIfgHejmOTdJs499Vq22jw%3D%3D",
+          "https://storage.googleapis.com/vue-course-api.appspot.com/gymplus/1709447603909.jpg",
         avatarUrl:
-          "https://storage.googleapis.com/vue-course-api.appspot.com/gymplus/1709447620951.png?GoogleAccessId=firebase-adminsdk-zzty7%40vue-course-api.iam.gserviceaccount.com&Expires=1742169600&Signature=O7fbmLEvyYW9quhMiwsV9P61rdqJYPk28b1zhG9HGNW05GgB972f3vcMf6a383AyavMz2Z2LZNDeWReyTEyjgRglmHHSz8jWUI6OfTtwp1aZs8QzBadHNpAmsc7sKpUPJSGCbw15TH5YBTsfz6Sbjt5IX5d4U9bKOqI2EwSeb4LfICWrnQpEitjNLV2gOlxA0G7Wz%2FAgI7QXSG0s3b%2B3LbQZB0OiBRlyo22KaGpYEYL1Ww%2FXrXO%2FW%2FBPMR1UDF2zO1OSTOKzLmQmSM%2BpVNCi8Q3F1OPnsJfCCRfLZZHPpGE1RlGLtv7spuK%2BQsxCYuMllwYsblvNy5bwN5LIw2f%2FTA%3D%3D",
+          "https://storage.googleapis.com/vue-course-api.appspot.com/gymplus/1709447620951.png",
         motto: ["融合心靈", "追求平衡", "通向內在自我"],
         teachingExpertise: [
           "瑜珈哲學與心靈實踐",
@@ -173,6 +173,6 @@ export default defineStore("fackDataStore", {
       },
     },
     // 文章分類
-    articleTags: ['健身好處', '健身知識', '營養素', '開課訊息'],
+    articleTags: ["健身好處", "健身知識", "營養素", "開課訊息"],
   }),
 });


### PR DESCRIPTION
2025.03 以後圖片授權到期
伺服器圖片儲存服務設定已更新，但寫在專案內的圖片連結需要手動更新
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update image URLs in `FakeDataStore.js` to remove expiration parameters, ensuring validity beyond March 2025.
> 
>   - **Behavior**:
>     - Updated image URLs in `FakeDataStore.js` to remove expiration parameters, ensuring they remain valid beyond March 2025.
>   - **Misc**:
>     - Minor formatting change in `FakeDataStore.js` for `articleTags` array.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ashkuan%2FGYMPlus&utm_source=github&utm_medium=referral)<sup> for 63850c9e0925d41ca841689c6363616e194e4150. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->